### PR TITLE
remove C++ namespace; rename constants

### DIFF
--- a/Source/CHttpServer/include/esp_http_includes.h
+++ b/Source/CHttpServer/include/esp_http_includes.h
@@ -11,9 +11,7 @@ const char* httpd_req_get_uri(httpd_req_t* request) {
 	return request->uri;
 }
 
-namespace httpd_shims {
-	const esp_err_t _ESP_ERR_HTTPD_ALLOC_MEM = ESP_ERR_HTTPD_ALLOC_MEM;
-	const esp_err_t _ESP_ERR_HTTPD_TASK = ESP_ERR_HTTPD_TASK;
-	const esp_err_t _ESP_ERR_HTTPD_HANDLERS_FULL = ESP_ERR_HTTPD_HANDLERS_FULL;
-	const esp_err_t _ESP_ERR_HTTPD_HANDLER_EXISTS = ESP_ERR_HTTPD_HANDLER_EXISTS;
-}
+const esp_err_t HTTPD_SHIMS_ESP_ERR_HTTPD_ALLOC_MEM = ESP_ERR_HTTPD_ALLOC_MEM;
+const esp_err_t HTTPD_SHIMS_ESP_ERR_HTTPD_TASK = ESP_ERR_HTTPD_TASK;
+const esp_err_t HTTPD_SHIMS_ESP_ERR_HTTPD_HANDLERS_FULL = ESP_ERR_HTTPD_HANDLERS_FULL;
+const esp_err_t HTTPD_SHIMS_ESP_ERR_HTTPD_HANDLER_EXISTS = ESP_ERR_HTTPD_HANDLER_EXISTS;

--- a/Source/HttpServer/Server.swift
+++ b/Source/HttpServer/Server.swift
@@ -37,8 +37,8 @@ public final class HttpServer {
 		switch httpd_start(&handle, &config) {
 			case ESP_OK: break
 			case ESP_ERR_INVALID_ARG: throw HttpServerError.invalidArgument
-			case httpd_shims._ESP_ERR_HTTPD_ALLOC_MEM: throw HttpServerError.allocationFailed
-			case httpd_shims._ESP_ERR_HTTPD_TASK: throw HttpServerError.taskCreateFailed
+			case HTTPD_SHIMS_ESP_ERR_HTTPD_ALLOC_MEM: throw HttpServerError.allocationFailed
+			case HTTPD_SHIMS_ESP_ERR_HTTPD_TASK: throw HttpServerError.taskCreateFailed
 			case let code: throw HttpServerError.unknown(errorCode: code) 
 		}
 		
@@ -73,8 +73,8 @@ public final class HttpServer {
 		switch success {
 			case ESP_OK: break
 			case ESP_ERR_INVALID_ARG: throw HttpServerError.invalidArgument
-			case httpd_shims._ESP_ERR_HTTPD_HANDLERS_FULL: throw HttpServerError.handlersFull
-			case httpd_shims._ESP_ERR_HTTPD_HANDLER_EXISTS: throw HttpServerError.handlerExists
+			case HTTPD_SHIMS_ESP_ERR_HTTPD_HANDLERS_FULL: throw HttpServerError.handlersFull
+			case HTTPD_SHIMS_ESP_ERR_HTTPD_HANDLER_EXISTS: throw HttpServerError.handlerExists
 			case let errorCode: throw HttpServerError.unknown(errorCode: errorCode)
 		}
 	}


### PR DESCRIPTION
ref: https://github.com/anders0nmat/swift-esp-http/issues/1

(this isn't really my patch; but providing it for ease of merge if that's wanted)